### PR TITLE
Allow overriding of the ATInternet tracker instance

### DIFF
--- a/BatchATInternetDispatcher.xcodeproj/project.pbxproj
+++ b/BatchATInternetDispatcher.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		511CBF5B25D6FF55004E92D9 /* Tracker.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 511CBF5425D6FF4C004E92D9 /* Tracker.xcframework */; };
 		511CBF6425D701EC004E92D9 /* Batch in Frameworks */ = {isa = PBXBuildFile; productRef = 511CBF6325D701EC004E92D9 /* Batch */; };
 		511CBF6825D701F6004E92D9 /* Batch in Frameworks */ = {isa = PBXBuildFile; productRef = 511CBF6725D701F6004E92D9 /* Batch */; };
+		511CBF7525DAB763004E92D9 /* BatchTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 511CBF7425DAB763004E92D9 /* BatchTrackerTests.m */; };
 		62BD2DAF2428C52000C5A5DB /* BatchATInternetDispatcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51D530F4241260A7009E7531 /* BatchATInternetDispatcher.framework */; };
 		62BD2DC02428C5BD00C5A5DB /* BatchXtorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 62BD2DB72428C5BD00C5A5DB /* BatchXtorTests.m */; };
 		62BD2DC12428C5BD00C5A5DB /* BatchAtInternetDispatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 62BD2DB82428C5BD00C5A5DB /* BatchAtInternetDispatcherTests.m */; };
@@ -56,6 +57,7 @@
 		510537962412625600589FC6 /* BatchATInternetDispatcherCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BatchATInternetDispatcherCore.h; path = Classes/BatchATInternetDispatcherCore.h; sourceTree = "<group>"; };
 		511CBF5325D6FF4C004E92D9 /* OCMock.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OCMock.xcframework; path = Carthage/Build/OCMock.xcframework; sourceTree = "<group>"; };
 		511CBF5425D6FF4C004E92D9 /* Tracker.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Tracker.xcframework; path = Carthage/Build/Tracker.xcframework; sourceTree = "<group>"; };
+		511CBF7425DAB763004E92D9 /* BatchTrackerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BatchTrackerTests.m; sourceTree = "<group>"; };
 		51D530F4241260A7009E7531 /* BatchATInternetDispatcher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BatchATInternetDispatcher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		62BD2DAA2428C52000C5A5DB /* BatchATInternetDispatcherTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BatchATInternetDispatcherTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		62BD2DB52428C5BD00C5A5DB /* BatchPayloadDispatcherTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BatchPayloadDispatcherTests.h; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 				62BD2DBC2428C5BD00C5A5DB /* BatchCampaignTests.m */,
 				62BD2DB52428C5BD00C5A5DB /* BatchPayloadDispatcherTests.h */,
 				62BD2DBB2428C5BD00C5A5DB /* BatchPayloadDispatcherTests.m */,
+				511CBF7425DAB763004E92D9 /* BatchTrackerTests.m */,
 				62BD2DB72428C5BD00C5A5DB /* BatchXtorTests.m */,
 				62BD2DBD2428C5BD00C5A5DB /* en.lproj */,
 				62BD2DB92428C5BD00C5A5DB /* Info.plist */,
@@ -290,6 +293,7 @@
 			files = (
 				62BD2DC42428C5BD00C5A5DB /* BatchCampaignTests.m in Sources */,
 				62BD2DC32428C5BD00C5A5DB /* BatchPayloadDispatcherTests.m in Sources */,
+				511CBF7525DAB763004E92D9 /* BatchTrackerTests.m in Sources */,
 				62BD2DC12428C5BD00C5A5DB /* BatchAtInternetDispatcherTests.m in Sources */,
 				62BD2DC02428C5BD00C5A5DB /* BatchXtorTests.m in Sources */,
 			);

--- a/BatchATInternetDispatcher/Classes/BatchATInternetDispatcherCore.h
+++ b/BatchATInternetDispatcher/Classes/BatchATInternetDispatcherCore.h
@@ -1,7 +1,16 @@
 #import <Batch/BatchEventDispatcher.h>
+#import <Tracker/Tracker-Swift.h>
 
 @interface BatchATInternetDispatcher : NSObject <BatchEventDispatcherDelegate>
 
 + (nonnull instancetype)instance;
+
+/// ATInternet tracker instance override.
+/// If this is nil, Batch will instantiate and use two trackers ("batch-campaign-tracker", "batch-publisher-tracker)
+/// using [ATInternet.sharedInstance tracker]. This can cause issue if you configure a tracker instance manually,
+/// without using ATInternet's plist-based configuration.
+/// Change this property to provide your own tracker instance.
+/// nil by default.
+@property (nullable) Tracker *trackerOverride;
 
 @end

--- a/BatchATInternetDispatcher/Classes/BatchATInternetDispatcherCore.m
+++ b/BatchATInternetDispatcher/Classes/BatchATInternetDispatcherCore.m
@@ -13,6 +13,7 @@ NSString* const BatchAtInternetPublisherTracker = @"batch-publisher-tracker";
 @implementation BatchATInternetDispatcher
 {
     NSMutableDictionary *_trackerCache;
+    Tracker *_trackerOverride;
 }
 
 + (void)load {
@@ -34,14 +35,35 @@ NSString* const BatchAtInternetPublisherTracker = @"batch-publisher-tracker";
 {
     self = [super init];
     if (self) {
+        _trackerOverride = nil;
         _trackerCache = [NSMutableDictionary new];
     }
     return self;
 }
+
+- (Tracker *)trackerOverride
+{
+    return _trackerOverride;
+}
+
+- (void)setTrackerOverride:(Tracker *)trackerOverride
+{
+    _trackerOverride = trackerOverride;
+    if (trackerOverride != nil) {
+        @synchronized (_trackerCache) {
+            [_trackerCache removeAllObjects];
+        }
+    }
+}
+
 - (Tracker*)trackerNamed:(nonnull NSString*)name
 {
     if (name == nil) {
         return nil;
+    }
+    
+    if (_trackerOverride != nil) {
+        return _trackerOverride;
     }
     
     Tracker *cachedTracker = [_trackerCache objectForKey:name];

--- a/BatchATInternetDispatcherTests/BatchATInternetDispatcherTests.m
+++ b/BatchATInternetDispatcherTests/BatchATInternetDispatcherTests.m
@@ -30,18 +30,12 @@
     _publisherMock = OCMClassMock([Publisher class]);
     _publishersMock = OCMClassMock([Publishers class]);
     _trackerMock = OCMClassMock([Tracker class]);
-    _atInternetMock = OCMClassMock([ATInternet class]);
-
-    OCMStub(ClassMethod([_atInternetMock sharedInstance])).andReturn(_atInternetMock);
-    
-    OCMStub([_atInternetMock defaultTracker]).andReturn(_trackerMock);
-    OCMStub([_atInternetMock tracker:@"batch-campaign-tracker"]).andReturn(_trackerMock);
-    OCMStub([_atInternetMock tracker:@"batch-publisher-tracker"]).andReturn(_trackerMock);
     
     OCMStub([_trackerMock publishers]).andReturn(_publishersMock);
     OCMStub([_trackerMock screens]).andReturn(_screensMock);
     
     _dispatcher = [BatchATInternetDispatcher instance];
+    _dispatcher.trackerOverride = _trackerMock;
 }
 
 - (void)tearDown

--- a/BatchATInternetDispatcherTests/BatchTrackerTests.m
+++ b/BatchATInternetDispatcherTests/BatchTrackerTests.m
@@ -1,0 +1,88 @@
+//
+//  Copyright © Batch. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <Tracker/Tracker-Swift.h>
+#import <OCMock/OCMock.h>
+
+#import "BatchATInternetDispatcher.h"
+#import "BatchPayloadDispatcherTests.h"
+
+// Expose private APIs to only test which tracker is
+
+@interface BatchTrackerTests : XCTestCase
+
+@end
+
+@implementation BatchTrackerTests
+
+/// Test that the dispatcher uses two trackers based on the default configuration
+- (void)testUseDefaultTracker {
+    id atInternetMock = OCMClassMock([ATInternet class]);
+    
+    id screenMock = OCMClassMock([Screen class]);
+    id screensMock = OCMClassMock([Screens class]);
+    OCMStub([(Screens*)screensMock add:[OCMArg any]]).andReturn(screenMock);
+    
+    id campaignTrackerMock = OCMClassMock([Tracker class]);
+    OCMStub([campaignTrackerMock screens]).andReturn(screensMock);
+    
+    id publisherMock = OCMClassMock([Publisher class]);
+    id publishersMock = OCMClassMock([Publishers class]);
+    OCMStub([(Publishers*)publishersMock add:[OCMArg any]]).andReturn(publisherMock);
+    
+    id publisherTrackerMock = OCMClassMock([Tracker class]);
+    OCMStub([publisherTrackerMock publishers]).andReturn(publishersMock);
+
+    OCMStub(ClassMethod([atInternetMock sharedInstance])).andReturn(atInternetMock);
+    
+    OCMStub([atInternetMock tracker:@"batch-campaign-tracker"]).andReturn(campaignTrackerMock);
+    OCMStub([atInternetMock tracker:@"batch-publisher-tracker"]).andReturn(publisherTrackerMock);
+    
+    [self sendTestEventUsingDispatcher:[BatchATInternetDispatcher new]];
+    
+    OCMVerify([screenMock sendView]);
+    OCMVerify([publisherMock sendImpression]);
+}
+
+/// Test that the dispatcher uses the overriden tracker in any case
+- (void)testOverrideTracker {
+    // Make sure ATInternet is never asked for anything: a strict mock
+    // will throw on any message
+    id atInternetMock = OCMStrictClassMock([ATInternet class]);
+    OCMStub(ClassMethod([atInternetMock sharedInstance])).andReturn(atInternetMock);
+    
+    // -----
+    // Setup our mock override tracker
+    
+    id screenMock = OCMClassMock([Screen class]);
+    id screensMock = OCMClassMock([Screens class]);
+    OCMStub([(Screens*)screensMock add:[OCMArg any]]).andReturn(screenMock);
+
+    id publisherMock = OCMClassMock([Publisher class]);
+    id publishersMock = OCMClassMock([Publishers class]);
+    OCMStub([(Publishers*)publishersMock add:[OCMArg any]]).andReturn(publisherMock);
+    
+    id trackerMock = OCMClassMock([Tracker class]);
+    OCMStub([trackerMock screens]).andReturn(screensMock);
+    OCMStub([trackerMock publishers]).andReturn(publishersMock);
+
+    // -----
+    
+    BatchATInternetDispatcher *dispatcher = [BatchATInternetDispatcher new];
+    dispatcher.trackerOverride = trackerMock;
+    [self sendTestEventUsingDispatcher:dispatcher];
+    
+    OCMVerify([screenMock sendView]);
+    OCMVerify([publisherMock sendImpression]);
+}
+
+- (void)sendTestEventUsingDispatcher:(BatchATInternetDispatcher*)dispatcher {
+    BatchPayloadDispatcherTest *testPayload = [[BatchPayloadDispatcherTest alloc] init];
+    testPayload.deeplink = @"https://batch.com/test?xtor=CS2-[mylabeltesttoto]-test-15[sef]";
+    
+    [dispatcher dispatchEventWithType:BatchEventDispatcherTypeMessagingShow payload:testPayload];
+}
+
+@end

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ DERIVED_DATA=$(CURDIR)/DerivedData
 SONAR_HOME=$(CURDIR)/.sonar
 SONAR_WORKDIR=$(CURDIR)/.scannerwork/
 SONAR_URL=https://sonarcloud.io
+GITHUB_ACCESS_TOKEN=$(GITHUB_TOKEN)
+
+.PHONY: ci carthage clean
 
 clean:
 	rm -rf $(DERIVED_DATA) $(SONAR_WORKDIR)


### PR DESCRIPTION
This PR adds a public API (a property) on the dispatcher, allowing developers to override the Tracker instance that will be used to track events.

This is useful for use cases where consumers configure their Tracker instances in code rather than using a plist.